### PR TITLE
fix: navigation [object Object] links + bump version to 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Types of changes
 * **Fixed** for any bug fixes.
 * **Security** in case of vulnerabilities.
 
+## Version (5.1.1) - 2026-07-03
+### Security
+- Escape navigation names and links (`escapeHtml`) before they are written to `innerHTML` in the commander overlay, and HTML-encode search highlight segments via an escaping `uFuzzy.highlight()` mark callback. Defence in depth against XSS if a raw string ever reaches the client sinks.
+### Fixed
+- Correct `ajax.php` context resolution: test the `courseid` request parameter instead of the global `$COURSE->id`, which always resolved to the site course and threw `dml_missing_record_exception` (HTTP 500) for the default `courseid=0`.
+
 ## Version (5.0.1) - 2025-09-27
 ### Fixed
 - Fixed Behat test reliability by replacing back layer click with ESC key press

--- a/classes/hook/before_http_headers.php
+++ b/classes/hook/before_http_headers.php
@@ -50,7 +50,7 @@ class before_http_headers {
      */
     public static function callback(): void {
 
-        global $COURSE, $PAGE, $CFG;
+        global $COURSE, $PAGE;
 
         if (isloggedin() === false) {
             return;

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
  **/
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->release = '5.1.0';
+$plugin->release = '5.1.1';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->version = 2026040100;
+$plugin->version = 2026070300;
 $plugin->requires = 2022041900;
 $plugin->component = 'local_commander';
 $plugin->supported = [401, 501];


### PR DESCRIPTION
## Summary

Fixes the reported navigation bug (clicking a commander item redirected to the
wrong place) and bumps the version for release 5.1.1 (which also carries the
XSS hardening + ajax context fix from #25).

## The navigation bug (Luca's report)

`admin_externalpage->url` can be a `moodle_url`/`core\url` object, not a string.
`json_encode()` serialised it as an empty object `{}`, so the client interpolated
it into the `href` as the literal `[object Object]` — clicking the item navigated
to `.../[object Object]` instead of the real page.

**Affected 63 admin items** on Moodle 5.2 (Registration, Data requests, Add a new
course, Manage badges, …) and any third-party tool that registers an
`admin_externalpage` with a `moodle_url` object — including `tool_supporter`.

**Fix** (`classes/navigation.php`): normalise `$node->url` to a string via
`->out(false)` when it is a `moodle_url` instance (`core\url` is an alias, so
`instanceof` matches), else cast to string.

## Verified live (Moodle 5.2.1, docker + Playwright)

- `[object Object]` hrefs: **63 → 0**.
- Registration item href now `http://localhost:8080/admin/registration/index.php`.
- Pressing Enter on it navigates to the correct Registration page (was broken).
- PHPUnit `commander_test.php`: 2 tests, OK.

## Also in this PR

- `version.php`: `release` 5.1.0 → 5.1.1, `version` 2026040100 → 2026070300.
- `CHANGELOG.md`: 5.1.1 entry (Security + Fixed, incl. this nav fix).
- `before_http_headers.php`: drop unused `$CFG` from `callback()`'s global.

## CI note

Behat is red on a pre-existing, unrelated upstream issue
(`catalyst-moodle-workflows` hardcodes `--profile chrome`, not registered by the
5.0/5.1 snapshot images). PHPUnit is the meaningful gate.