### PR TITLE
fix: normalise admin_externalpage url objects to string links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Types of changes
 ### Security
 - Escape navigation names and links (`escapeHtml`) before they are written to `innerHTML` in the commander overlay, and HTML-encode search highlight segments via an escaping `uFuzzy.highlight()` mark callback. Defence in depth against XSS if a raw string ever reaches the client sinks.
 ### Fixed
+- Fix admin navigation links that pointed to `[object Object]`: `admin_externalpage->url` can be a `moodle_url`/`core\url` object, which was serialised into JSON as an empty object and became `[object Object]` client-side. Normalise it to a string URL via `->out(false)`. Affected 60+ admin items (Registration, Data requests, Add a new course, Manage badges, and any third-party tool such as `tool_supporter`).
 - Correct `ajax.php` context resolution: test the `courseid` request parameter instead of the global `$COURSE->id`, which always resolved to the site course and threw `dml_missing_record_exception` (HTTP 500) for the default `courseid=0`.
 
 ## Version (5.0.1) - 2025-09-27

--- a/classes/navigation.php
+++ b/classes/navigation.php
@@ -104,7 +104,9 @@ class navigation {
         if ($node instanceof \admin_settingpage) {
             $attributes['link'] = (new moodle_url('/admin/settings.php', ['section' => $node->name]))->out(false);
         } else if ($node instanceof \admin_externalpage) {
-            $attributes['link'] = $node->url ?? '#';
+            // $node->url may be a plain string or a moodle_url/core\url object; normalise to a string URL.
+            $url = $node->url ?? '#';
+            $attributes['link'] = ($url instanceof moodle_url) ? $url->out(false) : (string)$url;
         }
 
         if ($node instanceof \admin_category && !empty($node->children)) {


### PR DESCRIPTION
admin_externalpage->url may be a moodle_url/core\url object rather than a string. json_encode serialised it as an empty object ({}), so the client interpolated it into href as the literal '[object Object]' and clicking the item navigated to the wrong place (reported for tool_supporter, but affected 60+ core admin items: Registration, Data requests, Add a new course, etc.).

Normalise to a string URL via ->out(false) when it is a moodle_url instance (core\url is an alias, so instanceof matches), else cast to string.

Verified live on Moodle 5.2: [object Object] hrefs 63 -> 0; the Registration item now navigates to /admin/registration/index.php.